### PR TITLE
Replace Timer with ScheduledExecutorService in actionbar

### DIFF
--- a/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/util/ActionbarUtil.java
+++ b/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/util/ActionbarUtil.java
@@ -4,32 +4,34 @@ import net.kyori.adventure.text.Component;
 import de.pascalpex.deepslatemc.files.Config;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
-import java.util.Timer;
-import java.util.TimerTask;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class ActionbarUtil {
 
     private static Component title;
-    private static final Timer timer = new Timer();
-    private static TimerTask task;
+    private static ScheduledExecutorService executor;
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
 
     public static void reloadActionbar() {
-        if (task != null) {
-            task.cancel();
+        if (executor != null) {
+            executor.shutdown();
         }
         if (!Config.getActionbarEnabled()) {
+            executor = null;
             return;
         }
 
-        task = new TimerTask() {
-            @Override
-            public void run() {
-                Bukkit.getOnlinePlayers().forEach(player -> player.sendActionBar(title));
-            }
-        };
-
         title = miniMessage.deserialize(Config.getActionbarText());
-        timer.scheduleAtFixedRate(task, 500, 1500);
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "DeepslateMC-Actionbar");
+            t.setDaemon(true);
+            return t;
+        });
+        executor.scheduleAtFixedRate(() -> {
+            Bukkit.getOnlinePlayers().forEach(player -> player.sendActionBar(title));
+        }, 500, 1500, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
Replaced Timer with ScheduledExecutorService to fix thread leak on reload and moved title assignment before scheduling to fix race condition