### PR TITLE
Replace 150 empty broadcasts with single component in clearchat

### DIFF
--- a/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/ClearchatCommand.java
+++ b/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/ClearchatCommand.java
@@ -24,9 +24,7 @@ public class ClearchatCommand implements Command<CommandSourceStack> {
     @Override
     public int run(CommandContext<CommandSourceStack> commandContext) throws CommandSyntaxException {
         Component prefix = MessagesFile.getMessage(MessagesEntry.PREFIX).appendSpace();
-        for (int x = 0; x < 150; x++){
-            Bukkit.broadcast(Component.empty());
-        }
+        Bukkit.broadcast(Component.text("\n".repeat(150)));
         Component clearMessage = MessagesFile.getMessage(MessagesEntry.CLEARED_CHAT).replaceText(TextReplacementConfig.builder().match("%clearer%").replacement(commandContext.getSource().getSender().getName()).build());
         Bukkit.broadcast(prefix.append(clearMessage));
         return SINGLE_SUCCESS;


### PR DESCRIPTION
Reduce packet spam in clearchat by using a single component with newlines instead of 150 separate broadcasts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DeepslateMC/codesmith/DeepslateMC/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784303073&installation_id=140843999&pr_number=9&repository=DeepslateMC%2FDeepslateMC&return_to=https%3A%2F%2Fgithub.com%2FDeepslateMC%2FDeepslateMC%2Fpull%2F9&signature=89d768af6dda9fa2c525cfcd71145a992f53c8ecfb1a353cd30dad2fb23dde14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->