### PR TITLE
Fix NPE in buildworld when world is not set

### DIFF
--- a/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/BuildworldCommand.java
+++ b/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/BuildworldCommand.java
@@ -30,7 +30,7 @@ public class BuildworldCommand implements Command<CommandSourceStack> {
         try {
             commandContext.getSource().getExecutor().teleport(Bukkit.getWorld(Config.getBuildworld()).getSpawnLocation());
             sender.sendMessage(prefix.append(MessagesFile.getMessage(MessagesEntry.BUILDWORLD_WELCOME)));
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             sender.sendMessage(prefix.append(MessagesFile.getMessage(MessagesEntry.BUILDWORLD_NOT_SET)));
         }
         return SINGLE_SUCCESS;


### PR DESCRIPTION
Fix NPE in buildworld when the configured world is null or not loaded

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DeepslateMC/codesmith/DeepslateMC/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784368224&installation_id=140843999&pr_number=10&repository=DeepslateMC%2FDeepslateMC&return_to=https%3A%2F%2Fgithub.com%2FDeepslateMC%2FDeepslateMC%2Fpull%2F10&signature=fc7dc193698ed36845fee8bb6e12251a6f1889ca12c4e481405be59394305218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->