### PR TITLE
Add missing permission checks to help and discord commands

### DIFF
--- a/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/DiscordCommand.java
+++ b/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/DiscordCommand.java
@@ -15,6 +15,7 @@ public class DiscordCommand implements Command<CommandSourceStack> {
     public static LiteralCommandNode<CommandSourceStack> create() {
         return Commands.literal("discord")
             .executes(new DiscordCommand())
+            .requires(commandSourceStack -> commandSourceStack.getSender().hasPermission("deepslate.discord"))
             .build();
     }
 

--- a/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/HelpCommand.java
+++ b/deepslateMC-server/src/main/java/de/pascalpex/deepslatemc/commands/HelpCommand.java
@@ -14,6 +14,7 @@ public class HelpCommand implements Command<CommandSourceStack> {
     public static LiteralCommandNode<CommandSourceStack> create() {
         return Commands.literal("help")
             .executes(new HelpCommand())
+            .requires(commandSourceStack -> commandSourceStack.getSender().hasPermission("deepslate.help"))
             .build();
     }
 


### PR DESCRIPTION
/help and /discord commands were accessible to all players without any permission check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DeepslateMC/codesmith/DeepslateMC/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784368737&installation_id=140843999&pr_number=12&repository=DeepslateMC%2FDeepslateMC&return_to=https%3A%2F%2Fgithub.com%2FDeepslateMC%2FDeepslateMC%2Fpull%2F12&signature=045af06f82b3d35ef3da80accc0751f1a484315546d97019ec066259437718fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->